### PR TITLE
fix: database errors

### DIFF
--- a/src/main/java/kr/co/seok/dto/MatterMostGroup.java
+++ b/src/main/java/kr/co/seok/dto/MatterMostGroup.java
@@ -9,13 +9,18 @@ import javax.persistence.*;
 @Setter
 @ToString
 @NoArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {"group_noti_time", "url_id"}
+        )
+})
 public class MatterMostGroup{
     @Id
     @Column(name = "group_id")
     @GeneratedValue
     private Long groupId;
 
-    @Column(name = "group_noti_time")
+    @Column(name = "group_noti_time", nullable = false)
     private String time;
 
     @ManyToOne


### PR DESCRIPTION
fixes msnodeve/mattermost-alert-bot-manager#13

- Do not allow null values in the group url time field.
- Do not allow null values in the group message field.
- Do not allow null values in url and alias field in url table.
- Set time and url fields to be unique to each other in the group table.